### PR TITLE
ADDED: missing new

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ npm install --save comlog-ftp
 ```js
 var FTPClient = require('comlog-ftp');
 
-var conn = FTPClient({
+var conn = new FTPClient({
     host: 'localhost', // Default localhost
     port: 21, // Default 12
     user: 'username', // Default anonymous
@@ -34,7 +34,7 @@ conn.connect(function(err) {
 ```js
 var FTPClient = require('comlog-ftp');
 
-var conn = FTPClient({
+var conn = new FTPClient({
     host: 'localhost', // Default localhost
     port: 21, // Default 12
     user: 'username', // Default anonymous


### PR DESCRIPTION
If `new` is omitted, `this` will point to window and the following error is displayed:

>         this.on('220', function (chunk) {
>             ^
>
> TypeError: this.on is not a function